### PR TITLE
add frontend docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:lts-alpine AS vite-build
+WORKDIR /build
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:stable-alpine AS serve-pages
+COPY --from=vite-build /build/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Adds a docker file that can serve the front end as a single container. The docker container requires the environment variables to be set up correctly in order to function.